### PR TITLE
Improve JavaScript target code template.

### DIFF
--- a/dotnet-antlr/GenBuild.cs
+++ b/dotnet-antlr/GenBuild.cs
@@ -147,7 +147,7 @@ exit $err
 </Project>");
                 var fn = p.outputDirectory + "Test.csproj";
                 System.IO.File.WriteAllText(fn, Program.Localize(p.line_translation, sb.ToString()));
-                
+
                 sb = new StringBuilder();
                 sb.AppendLine(@"
 # Generated code from Antlr4BuildTasks.dotnet-antlr v " + Program.version + @"
@@ -228,19 +228,16 @@ run:
                 sb = new StringBuilder();
                 sb.AppendLine(@"
 {
-  ""name"": ""i"",
+  ""name"": """ + p.parser_name + @""",
+  ""private"": true,
   ""version"": ""1.0.0"",
-  ""description"": """",
   ""main"": ""index.js"",
-  ""scripts"": {
-    ""test"": ""echo \""Error: no test specified\"" && exit 1""
-  },
-  ""author"": """",
-  ""license"": ""ISC"",
   ""dependencies"": {
     ""antlr4"": ""^4.9.1"",
-    ""fs-extra"": ""^9.1.0"",
-    ""typescript-string-operations"": ""^1.4.1""
+    ""get-stdin-with-tty"": ""^6.0.0""
+  },
+  ""engines"": {
+    ""node"": ""^14.8.0""
   },
   ""type"": ""module""
 }


### PR DESCRIPTION
- Added `private` field in `package.json`, to prevent someone accidentally publish the generated code into NPM repository.
- Use `get-stdin-with-tty` to read stdin as a string (`fs.readFileSync(0,'utf-8')` not works well on windows, https://github.com/nodejs/node/issues/19831).
- Use `let` and `const` instead of `var`.
- Move error count to a field inside `MyErrorListener` class

TODO: 
- Wait for ANTLR version and update dependency, so we can avoid [those](https://github.com/antlr/antlr4/pull/3077) [bugs](https://github.com/antlr/antlr4/pull/3080) in JS runtime.
- Improve other code template.
- Use file (or whole directory) as template, so we needn't hard code them in C# code.