### PR TITLE
Fix overrding `<NoWarn />`

### DIFF
--- a/Antlr4BuildTasks/Antlr4BuildTasks.targets
+++ b/Antlr4BuildTasks/Antlr4BuildTasks.targets
@@ -257,7 +257,7 @@
 	</Target>
 
 <PropertyGroup>
-    <NoWarn>3021;1701;1702</NoWarn>
+    <NoWarn>$(NoWarn);3021;1701;1702</NoWarn>
 </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Just installing `Antlr4BuildTasks` 11.1.0 into NHibernate (no grammar files, nor `<Antlr4 />` elements in `<ItemGroup />`) is enough to trigger countless warnings in the project. In the project we have following warnings suppressed:

```xml
    <NoWarn>$(NoWarn);3001;3002;3003;3005;1591;419</NoWarn>
```

But with the `Antlr4BuildTasks` installed all of them become visible.

Worst part is that we have `<TreatWarningsAsErrors>True</TreatWarningsAsErrors>` enabled and now the project errors on build.