### PR TITLE
Fix MakeRelativeList task

### DIFF
--- a/Antlr4BuildTasks/Tasks/MakeRelativeList.cs
+++ b/Antlr4BuildTasks/Tasks/MakeRelativeList.cs
@@ -1,19 +1,20 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
+using System.IO;
 using System.Linq;
 using System.Collections.Generic;
-using Directory = System.IO.Directory;
 
 namespace Antlr4.Build.Tasks
 {
     public class MakeRelativeList : Task
     {
-        private List<ITaskItem> _result = new List<ITaskItem>();
-        internal string WorkingDirectory { get; set; } = Directory.GetCurrentDirectory();		
         public ITaskItem[] List1 { get; set; }
+        private List<ITaskItem> _result = new List<ITaskItem>();
+        internal string WorkingDirectory { get; set; } = Directory.GetCurrentDirectory();
 
-        [Output] public ITaskItem[] Result
+        [Output]
+        public ITaskItem[] Result
         {
             get { return _result.ToArray(); }
             set { _result = new List<ITaskItem>(value); }
@@ -24,16 +25,17 @@ namespace Antlr4.Build.Tasks
             try
             {
                 _result.Clear();
-                if (List1 == null) 
+                if (List1 == null)
                     List1 = Array.Empty<ITaskItem>();
 
                 var slash = Path.DirectorySeparatorChar;
+                var slashStr = slash.ToString();
 
                 // Normalize workDir
                 var workDir = Path.GetFullPath(WorkingDirectory);
-                if (!workDir.EndsWith(slash)) workDir += slash;
+                if (!workDir.EndsWith(slashStr)) workDir += slash;
                 var workDirRoot = Path.GetPathRoot(workDir);
-                var workDirFolders = workDir.Substring(workDirRoot.Length).Split(slash, StringSplitOptions.RemoveEmptyEntries);
+                var workDirFolders = workDir.Substring(workDirRoot.Length).Split(new[] { slash }, StringSplitOptions.RemoveEmptyEntries);
 
                 this.Log.LogMessage("MakeRelativeList input: '{0}'", String.Join("', '", List1.AsEnumerable()));
                 this.Log.LogMessage("MakeRelativeList working directory: '{0}'", workDir);
@@ -65,7 +67,10 @@ namespace Antlr4.Build.Tasks
                             Environment.OSVersion.Platform == PlatformID.Unix
                             ? StringComparison.Ordinal
                             : StringComparison.OrdinalIgnoreCase;
-                        var comparer = StringComparer.FromComparison(comparison);
+                        var comparer =
+                            Environment.OSVersion.Platform == PlatformID.Unix
+                            ? StringComparer.Ordinal
+                            : StringComparer.OrdinalIgnoreCase;
 
                         // Normalize path
                         path = Path.GetFullPath(path);
@@ -90,12 +95,12 @@ namespace Antlr4.Build.Tasks
                         }
 
                         // 2) Ignore all leading directories they have in common (beware UNC paths)...
-                        var pathSegments = path.Substring(pathRoot.Length).Split(slash, StringSplitOptions.RemoveEmptyEntries);
+                        var pathSegments = path.Substring(pathRoot.Length).Split(new[] { slash }, StringSplitOptions.RemoveEmptyEntries);
 
-                        var numCommon = 
+                        var numCommon =
                             Enumerable
-                                .Zip(workDirFolders, pathSegments)
-                                .TakeWhile(t => comparer.Equals(t.First, t.Second))
+                                .Zip(workDirFolders, pathSegments, Tuple.Create)
+                                .TakeWhile(t => comparer.Equals(t.Item1, t.Item2))
                                 .Count();
 
                         var remainingWorkDirs = workDirFolders.Skip(numCommon);
@@ -103,9 +108,9 @@ namespace Antlr4.Build.Tasks
 
                         // 2) What remains in `remainingWorkDirs` is the number of ".."s 
                         //    needed to get to the base of `remainingPathSegments`...
-                        var relative_path = String.Join(slash, remainingWorkDirs.Select(_ => "..").Concat(remainingPathSegments));
+                        var relative_path = String.Join(slashStr, remainingWorkDirs.Select(_ => "..").Concat(remainingPathSegments));
                         if (relative_path == "") relative_path = ".";
-                        if (path.EndsWith(slash)) relative_path += slash;
+                        if (path.EndsWith(slashStr)) relative_path += slash;
                         _result.Add(new TaskItem(relative_path));
                     }
                     catch (Exception e)

--- a/Antlr4BuildTasks/Tasks/MakeRelativeList.cs
+++ b/Antlr4BuildTasks/Tasks/MakeRelativeList.cs
@@ -8,10 +8,14 @@ using Directory = System.IO.Directory;
 namespace Antlr4.Build.Tasks
 {
     public class MakeRelativeList : Task
-    {
-        public ITaskItem[] List1 { get; set; }
-        private List<ITaskItem> _result = new List<ITaskItem>();
+	{
+		private List<ITaskItem> _result = new List<ITaskItem>();
+        
+        // For testing
+		internal string WorkingDirectory { get; set; } = Directory.GetCurrentDirectory();		
 
+		public ITaskItem[] List1 { get; set; }
+        
         [Output] public ITaskItem[] Result
         {
             get { return _result.ToArray(); }
@@ -20,53 +24,108 @@ namespace Antlr4.Build.Tasks
 
         public override bool Execute()
         {
-            bool success = false;
             try
-            {
-                this.Log.LogMessage("MakeRelativeList input is " + string.Join(", ", List1.ToList()));
-                _result = new List<ITaskItem>();
-                string current = Directory.GetCurrentDirectory();
-                current = current.Replace("\\", "/");
-                if (! current.EndsWith("/")) current = current + "/";
-                if (List1 != null)
+			{
+				_result.Clear();
+				if (List1 == null) 
+					List1 = Array.Empty<ITaskItem>();
+
+				var slash = Path.DirectorySeparatorChar;
+
+				// Normalize workDir
+				var workDir = Path.GetFullPath(WorkingDirectory);
+				if (!workDir.EndsWith(slash)) workDir += slash;
+				var workDirRoot = Path.GetPathRoot(workDir);
+				var workDirFolders = workDir.Substring(workDirRoot.Length).Split(slash, StringSplitOptions.RemoveEmptyEntries);
+
+				this.Log.LogMessage("MakeRelativeList input: '{0}'", String.Join("', '", List1.AsEnumerable()));
+				this.Log.LogMessage("MakeRelativeList working directory: '{0}'", workDir);
+
+				foreach (var v1 in List1)
                 {
-                    foreach (var v1 in List1)
-                    {
-                        if (v1 == null)
-                            continue;
-                        var f = v1.ItemSpec.ToString();
-                        try
-                        {
-                            var is_full_path = System.IO.Path.IsPathRooted(f);
-                            if (!is_full_path)
-                                f = System.IO.Path.GetFullPath(f);
-                            var absolute = f;
-                            absolute = absolute.Replace("\\", "/");
-                            string relative_path;
-                            if (absolute.ToLower().IndexOf(current.ToLower()) == 0)
-                                relative_path = absolute.Substring(current.Length);
-                            else
-                                relative_path = absolute;
-                            if (relative_path[0] == '/')
-                                relative_path = relative_path.Substring(1);
-                            _result.Add(new TaskItem() { ItemSpec = relative_path });
-                        }
-                        catch
-                        {
-                            _result.Add(v1);
-                        }
+                    if (v1 == null)
+                        continue;
+
+                    try
+					{
+						var path = v1.ItemSpec;
+						if (!Path.IsPathRooted(path))
+						{
+							// It is already relative. Just clean it up.
+							path = path.Replace(slash == '/' ? '\\' : '/', slash);
+							_result.Add(new TaskItem(path));
+							continue;
+						}
+
+						// - `path` is a full file or directory path.
+						// - `workDir` is a directory path ending with slash.
+
+						// Convert to a relative path *if possible*...
+						// If we upgrade to netstandard2.1 we can use `IO.Path.GetRelativePath`.
+						// Until then we have to do it the hard way...
+
+						var comparison =
+							Environment.OSVersion.Platform == PlatformID.Unix
+							? StringComparison.Ordinal
+							: StringComparison.OrdinalIgnoreCase;
+						var comparer = StringComparer.FromComparison(comparison);
+
+						// Normalize path
+						path = Path.GetFullPath(path);
+
+						// 0) Is path a direct subpath of workDir. This is often true.
+						if (path.StartsWith(workDir, comparison))
+						{
+							// Direct subpath
+							var relative_path1 = path.Substring(workDir.Length);
+							if (relative_path1 == "") relative_path1 = ".";
+							_result.Add(new TaskItem(relative_path1));
+							continue;
+						}
+
+						// 1) To be relative they must have a common root...
+						var pathRoot = Path.GetPathRoot(path);
+						if (!comparer.Equals(workDirRoot, pathRoot))
+						{
+							// Cannot be relative
+							_result.Add(new TaskItem(path));
+							continue;
+						}
+
+						// 2) Ignore all leading directories they have in common (beware UNC paths)...
+						var pathSegments = path.Substring(pathRoot.Length).Split(slash, StringSplitOptions.RemoveEmptyEntries);
+
+						var numCommon = 
+							Enumerable
+								.Zip(workDirFolders, pathSegments)
+								.TakeWhile(t => comparer.Equals(t.First, t.Second))
+								.Count();
+
+						var remainingWorkDirs = workDirFolders.Skip(numCommon);
+						var remainingPathSegments = pathSegments.Skip(numCommon);
+
+						// 2) What remains in `remainingWorkDirs` is the number of ".."s 
+						//    needed to get to the base of `remainingPathSegments`...
+						var relative_path = String.Join(slash, remainingWorkDirs.Select(_ => "..").Concat(remainingPathSegments));
+						if (relative_path == "") relative_path = ".";
+						if (path.EndsWith(slash)) relative_path += slash;
+                        _result.Add(new TaskItem(relative_path));
+                    }
+                    catch (Exception e)
+					{
+						this.Log.LogWarning("Error in MakeRelativeList while parsing '{0}': {1}\n{2}", v1.ItemSpec, e.Message, e.StackTrace);
+						_result.Add(v1);
                     }
                 }
-                success = true;
-                this.Log.LogMessage("MakeRelativeList output is " + string.Join(", ", _result.ToList()));
+
+				this.Log.LogMessage("MakeRelativeList output is '{0}'", String.Join("', '", _result));
+                return true; // success!
             }
             catch (Exception e)
             {
-                this.Log.LogMessage("Problem with MakeRelativeList "
-                    + e.Message + e.StackTrace
-                );
-            }
-            return success;
+				this.Log.LogWarning("Error in MakeRelativeList: {0}\n{1}", e.Message, e.StackTrace);
+				return false; // failure
+			}
         }
     }
 }

--- a/Antlr4BuildTasks/Tasks/MakeRelativeList.cs
+++ b/Antlr4BuildTasks/Tasks/MakeRelativeList.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
 using System.Linq;
@@ -8,14 +8,11 @@ using Directory = System.IO.Directory;
 namespace Antlr4.Build.Tasks
 {
     public class MakeRelativeList : Task
-	{
-		private List<ITaskItem> _result = new List<ITaskItem>();
-        
-        // For testing
-		internal string WorkingDirectory { get; set; } = Directory.GetCurrentDirectory();		
+    {
+        private List<ITaskItem> _result = new List<ITaskItem>();
+        internal string WorkingDirectory { get; set; } = Directory.GetCurrentDirectory();		
+        public ITaskItem[] List1 { get; set; }
 
-		public ITaskItem[] List1 { get; set; }
-        
         [Output] public ITaskItem[] Result
         {
             get { return _result.ToArray(); }
@@ -25,107 +22,107 @@ namespace Antlr4.Build.Tasks
         public override bool Execute()
         {
             try
-			{
-				_result.Clear();
-				if (List1 == null) 
-					List1 = Array.Empty<ITaskItem>();
+            {
+                _result.Clear();
+                if (List1 == null) 
+                    List1 = Array.Empty<ITaskItem>();
 
-				var slash = Path.DirectorySeparatorChar;
+                var slash = Path.DirectorySeparatorChar;
 
-				// Normalize workDir
-				var workDir = Path.GetFullPath(WorkingDirectory);
-				if (!workDir.EndsWith(slash)) workDir += slash;
-				var workDirRoot = Path.GetPathRoot(workDir);
-				var workDirFolders = workDir.Substring(workDirRoot.Length).Split(slash, StringSplitOptions.RemoveEmptyEntries);
+                // Normalize workDir
+                var workDir = Path.GetFullPath(WorkingDirectory);
+                if (!workDir.EndsWith(slash)) workDir += slash;
+                var workDirRoot = Path.GetPathRoot(workDir);
+                var workDirFolders = workDir.Substring(workDirRoot.Length).Split(slash, StringSplitOptions.RemoveEmptyEntries);
 
-				this.Log.LogMessage("MakeRelativeList input: '{0}'", String.Join("', '", List1.AsEnumerable()));
-				this.Log.LogMessage("MakeRelativeList working directory: '{0}'", workDir);
+                this.Log.LogMessage("MakeRelativeList input: '{0}'", String.Join("', '", List1.AsEnumerable()));
+                this.Log.LogMessage("MakeRelativeList working directory: '{0}'", workDir);
 
-				foreach (var v1 in List1)
+                foreach (var v1 in List1)
                 {
                     if (v1 == null)
                         continue;
 
                     try
-					{
-						var path = v1.ItemSpec;
-						if (!Path.IsPathRooted(path))
-						{
-							// It is already relative. Just clean it up.
-							path = path.Replace(slash == '/' ? '\\' : '/', slash);
-							_result.Add(new TaskItem(path));
-							continue;
-						}
+                    {
+                        var path = v1.ItemSpec;
+                        if (!Path.IsPathRooted(path))
+                        {
+                            // It is already relative. Just clean it up.
+                            path = path.Replace(slash == '/' ? '\\' : '/', slash);
+                            _result.Add(new TaskItem(path));
+                            continue;
+                        }
 
-						// - `path` is a full file or directory path.
-						// - `workDir` is a directory path ending with slash.
+                        // - `path` is a full file or directory path.
+                        // - `workDir` is a directory path ending with slash.
 
-						// Convert to a relative path *if possible*...
-						// If we upgrade to netstandard2.1 we can use `IO.Path.GetRelativePath`.
-						// Until then we have to do it the hard way...
+                        // Convert to a relative path *if possible*...
+                        // If we upgrade to netstandard2.1 we can use `IO.Path.GetRelativePath`.
+                        // Until then we have to do it the hard way...
 
-						var comparison =
-							Environment.OSVersion.Platform == PlatformID.Unix
-							? StringComparison.Ordinal
-							: StringComparison.OrdinalIgnoreCase;
-						var comparer = StringComparer.FromComparison(comparison);
+                        var comparison =
+                            Environment.OSVersion.Platform == PlatformID.Unix
+                            ? StringComparison.Ordinal
+                            : StringComparison.OrdinalIgnoreCase;
+                        var comparer = StringComparer.FromComparison(comparison);
 
-						// Normalize path
-						path = Path.GetFullPath(path);
+                        // Normalize path
+                        path = Path.GetFullPath(path);
 
-						// 0) Is path a direct subpath of workDir. This is often true.
-						if (path.StartsWith(workDir, comparison))
-						{
-							// Direct subpath
-							var relative_path1 = path.Substring(workDir.Length);
-							if (relative_path1 == "") relative_path1 = ".";
-							_result.Add(new TaskItem(relative_path1));
-							continue;
-						}
+                        // 0) Is path a direct subpath of workDir. This is often true.
+                        if (path.StartsWith(workDir, comparison))
+                        {
+                            // Direct subpath
+                            var relative_path1 = path.Substring(workDir.Length);
+                            if (relative_path1 == "") relative_path1 = ".";
+                            _result.Add(new TaskItem(relative_path1));
+                            continue;
+                        }
 
-						// 1) To be relative they must have a common root...
-						var pathRoot = Path.GetPathRoot(path);
-						if (!comparer.Equals(workDirRoot, pathRoot))
-						{
-							// Cannot be relative
-							_result.Add(new TaskItem(path));
-							continue;
-						}
+                        // 1) To be relative they must have a common root...
+                        var pathRoot = Path.GetPathRoot(path);
+                        if (!comparer.Equals(workDirRoot, pathRoot))
+                        {
+                            // Cannot be relative
+                            _result.Add(new TaskItem(path));
+                            continue;
+                        }
 
-						// 2) Ignore all leading directories they have in common (beware UNC paths)...
-						var pathSegments = path.Substring(pathRoot.Length).Split(slash, StringSplitOptions.RemoveEmptyEntries);
+                        // 2) Ignore all leading directories they have in common (beware UNC paths)...
+                        var pathSegments = path.Substring(pathRoot.Length).Split(slash, StringSplitOptions.RemoveEmptyEntries);
 
-						var numCommon = 
-							Enumerable
-								.Zip(workDirFolders, pathSegments)
-								.TakeWhile(t => comparer.Equals(t.First, t.Second))
-								.Count();
+                        var numCommon = 
+                            Enumerable
+                                .Zip(workDirFolders, pathSegments)
+                                .TakeWhile(t => comparer.Equals(t.First, t.Second))
+                                .Count();
 
-						var remainingWorkDirs = workDirFolders.Skip(numCommon);
-						var remainingPathSegments = pathSegments.Skip(numCommon);
+                        var remainingWorkDirs = workDirFolders.Skip(numCommon);
+                        var remainingPathSegments = pathSegments.Skip(numCommon);
 
-						// 2) What remains in `remainingWorkDirs` is the number of ".."s 
-						//    needed to get to the base of `remainingPathSegments`...
-						var relative_path = String.Join(slash, remainingWorkDirs.Select(_ => "..").Concat(remainingPathSegments));
-						if (relative_path == "") relative_path = ".";
-						if (path.EndsWith(slash)) relative_path += slash;
+                        // 2) What remains in `remainingWorkDirs` is the number of ".."s 
+                        //    needed to get to the base of `remainingPathSegments`...
+                        var relative_path = String.Join(slash, remainingWorkDirs.Select(_ => "..").Concat(remainingPathSegments));
+                        if (relative_path == "") relative_path = ".";
+                        if (path.EndsWith(slash)) relative_path += slash;
                         _result.Add(new TaskItem(relative_path));
                     }
                     catch (Exception e)
-					{
-						this.Log.LogWarning("Error in MakeRelativeList while parsing '{0}': {1}\n{2}", v1.ItemSpec, e.Message, e.StackTrace);
-						_result.Add(v1);
+                    {
+                        this.Log.LogWarning("Error in MakeRelativeList while parsing '{0}': {1}\n{2}", v1.ItemSpec, e.Message, e.StackTrace);
+                        _result.Add(v1);
                     }
                 }
 
-				this.Log.LogMessage("MakeRelativeList output is '{0}'", String.Join("', '", _result));
+                this.Log.LogMessage("MakeRelativeList output is '{0}'", String.Join("', '", _result));
                 return true; // success!
             }
             catch (Exception e)
             {
-				this.Log.LogWarning("Error in MakeRelativeList: {0}\n{1}", e.Message, e.StackTrace);
-				return false; // failure
-			}
+                this.Log.LogWarning("Error in MakeRelativeList: {0}\n{1}", e.Message, e.StackTrace);
+                return false; // failure
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses issue https://github.com/kaby76/Antlr4BuildTasks/issues/14 -- when given an absolute path outside of the working directory on linux, the `MakeRelativeList` task was converting the absolute path to an invalid relative path.

I implemented a full blown version of "GetRelativePath" which will return a correct relative path as long as the source path is on the same drive as the project directory. If they are not on same drive the original absolute path is returned.