### PR TITLE
feat: support temurin openjdk

### DIFF
--- a/Antlr4BuildTasks/Tasks/RunAntlrTool.cs
+++ b/Antlr4BuildTasks/Tasks/RunAntlrTool.cs
@@ -1218,7 +1218,7 @@ PackageVersion = '" + PackageVersion.ToString() + @"
             }
             try
             {
-                Regex valid_version_pattern = new Regex("(OpenJDK Runtime Environment [(]build (1[1-9]|[2-9][0-9]))|(Java[(]TM[)] SE Runtime Environment [(]build (1[1-9]|[2-9][0-9]))");
+                Regex valid_version_pattern = new Regex("(OpenJDK Runtime Environment [^()]*[(]build (1[1-9]|[2-9][0-9]))|(Java[(]TM[)] SE Runtime Environment [(]build (1[1-9]|[2-9][0-9]))");
                 var matches = valid_version_pattern.Matches(data);
                 var found = matches.Count > 0;
                 MessageQueue.EnqueueMessage(Message.BuildDefaultMessage("got matches " + matches.Count + " for '" + data + "'"));


### PR DESCRIPTION
Updated regex to support newer openjdk builds:

```
OpenJDK Runtime Environment Temurin-21.0.1+12 (build 21.0.1+12-LTS)
OpenJDK Runtime Environment Temurin-17.0.9+9 (build 17.0.9+9)
```


- https://regex101.com/r/okjGik/1