### PR TITLE
Print download exception to troubleshoot downloading problem

### DIFF
--- a/Antlr4BuildTasks/Tasks/RunAntlrTool.cs
+++ b/Antlr4BuildTasks/Tasks/RunAntlrTool.cs
@@ -433,10 +433,10 @@ PackageVersion = '" + PackageVersion.ToString() + @"
                     where = archive_name;
                     result = true;
                 }
-                catch
+                catch (Exception ex)
                 {
                     MessageQueue.EnqueueMessage(Message.BuildInfoMessage(
-                        "Problem downloading or saving probed file."));
+                        $"Problem downloading or saving probed file. {ex}"));
                 }
             }
             else if (path.StartsWith("https://") || path.StartsWith("http://"))
@@ -463,10 +463,10 @@ PackageVersion = '" + PackageVersion.ToString() + @"
                     where = archive_name;
                     result = true;
                 }
-                catch
+                catch (Exception ex)
                 {
                     MessageQueue.EnqueueMessage(Message.BuildInfoMessage(
-                        "Problem downloading or saving probed file."));
+                        $"Problem downloading or saving probed file. {ex}"));
                 }
             }
             else


### PR DESCRIPTION
We have a pipeline in Azure and frequently running into issues with downloading antlr4 jar. It would be nice to print out the actual exception rather than swallowing it for troubleshooting.