### PR TITLE
feat: add antlr-ng tool support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -85,3 +85,32 @@ jobs:
          name: build-output
          path: /home/runner/work/Antlr4BuildTasks/bin/Debug/*.*nupkg
          retention-days: 3
+
+  test-antlr-ng:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [20.x]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install antlr-ng
+      run: npm install -g antlr-ng
+    - name: Verify antlr-ng installation
+      run: antlr-ng --version
+    - name: Clean
+      run: make clean
+    - name: Build
+      run: make build
+    - name: Test antlr-ng
+      shell: bash
+      run: bash test-antlr-ng.sh

--- a/Antlr4BuildTasks/Antlr4BuildTasks.targets
+++ b/Antlr4BuildTasks/Antlr4BuildTasks.targets
@@ -118,6 +118,10 @@
             <Log>false</Log>
             <LongMessages>false</LongMessages>
             <Package></Package>
+            <ToolType>java</ToolType>
+            <NodeExec>PATH</NodeExec>
+            <NodeDownloadDirectory>USERPROFILE/.node/</NodeDownloadDirectory>
+            <AntlrNgPath></AntlrNgPath>
             <Visitor>true</Visitor>
         </Antlr4>
     </ItemDefinitionGroup>
@@ -160,6 +164,10 @@
                         TargetFrameworkVersion="$(TargetFrameworkVersion)"
                         TargetFrameworks="@(TargetFrameworks)"
                         TokensFiles="@(Antlr4Tokens)"
+                        ToolType="%(Antlr4.ToolType)"
+                        NodeExec="%(Antlr4.NodeExec)"
+                        NodeDownloadDirectory="%(Antlr4.NodeDownloadDirectory)"
+                        AntlrNgPath="%(Antlr4.AntlrNgPath)"
                         Visitor="%(Antlr4.Visitor)"
           >
             <Output ItemName="ToCompileFiles" TaskParameter="GeneratedCodeFiles" />

--- a/Antlr4BuildTasks/Antlr4BuildTasks.xml
+++ b/Antlr4BuildTasks/Antlr4BuildTasks.xml
@@ -111,6 +111,30 @@
             Default="false"
             DisplayName="long messages (-long-messages)"
             Description="Turn on long messages for Antlr tool." />
+        <StringProperty
+            Category="ANTLR"
+            Name="ToolType"
+            Default="java"
+            DisplayName="ANTLR Tool Type"
+            Description="Specifies which ANTLR tool to use: 'java' for the standard Java-based ANTLR4 tool, or 'antlr-ng' for the Node.js-based antlr-ng tool. Default is 'java'." />
+        <StringProperty
+            Category="ANTLR"
+            Name="NodeExec"
+            Default="PATH"
+            DisplayName="Full path of Node.js executable"
+            Description="This is a search path or full path of Node.js installed on your system. Only used when ToolType is 'antlr-ng'. The default is 'PATH', which searches the system PATH." />
+        <StringProperty
+            Category="ANTLR"
+            Name="NodeDownloadDirectory"
+            Default="USERPROFILE/.node/"
+            DisplayName="Full path of folder to store Node.js downloads"
+            Description="This is the full path of the location to store downloaded Node.js if needed. Only used when ToolType is 'antlr-ng'. The default is USERPROFILE/.node, which gets expanded to a path in the user's home directory for the OS." />
+        <StringProperty
+            Category="ANTLR"
+            Name="AntlrNgPath"
+            Default=""
+            DisplayName="Full path of antlr-ng CLI script"
+            Description="This is the full path of the antlr-ng CLI script (cli.js). Only used when ToolType is 'antlr-ng'. If blank, the tool will search in common npm installation locations (local node_modules, global npm, etc.)." />
 
         <!--
             The rest of these properties are not ANTLR-specific, but CPS provides no way to inherit properties, so if we fail to

--- a/Antlr4BuildTasks/Tools/AntlrNgTool.cs
+++ b/Antlr4BuildTasks/Tools/AntlrNgTool.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Antlr4.Build.Tasks;
+using Antlr4.Build.Tasks.Util;
+
+namespace Antlr4.Build.Tasks.Tools
+{
+    /// <summary>
+    /// Implementation for the Node.js-based antlr-ng tool
+    /// </summary>
+    public class AntlrNgTool : AntlrToolBase
+    {
+        public string NodeExecutable { get; set; }
+        public string AntlrNgPath { get; set; }
+
+        public AntlrNgTool() : base()
+        {
+        }
+
+        public override string ToolName => "antlr-ng";
+
+        public override bool Setup()
+        {
+            // Validate Node.js is available
+            if (string.IsNullOrEmpty(NodeExecutable))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(
+                    "Node.js executable path not set"));
+                return false;
+            }
+
+            if (!File.Exists(NodeExecutable))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(
+                    $"Node.js executable not found at: {NodeExecutable}"));
+                return false;
+            }
+
+            // Validate antlr-ng is available
+            if (string.IsNullOrEmpty(AntlrNgPath))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(
+                    "antlr-ng path not set"));
+                return false;
+            }
+
+            if (!File.Exists(AntlrNgPath))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(
+                    $"antlr-ng not found at: {AntlrNgPath}"));
+                return false;
+            }
+
+            return true;
+        }
+
+        public override bool DiscoverGeneratedFiles(
+            IEnumerable<string> grammarFiles,
+            out List<string> generatedFiles,
+            out List<string> generatedCodeFiles)
+        {
+            // antlr-ng doesn't have a -depend mode, so we predict the generated files
+            // based on grammar file analysis
+            generatedFiles = new List<string>();
+            generatedCodeFiles = new List<string>();
+
+            foreach (var grammarFile in grammarFiles)
+            {
+                try
+                {
+                    var predictedFiles = PredictGeneratedFiles(grammarFile);
+                    generatedFiles.AddRange(predictedFiles);
+                    generatedCodeFiles.AddRange(predictedFiles.Where(f => f.EndsWith(".cs")));
+                }
+                catch (Exception ex)
+                {
+                    MessageQueue.EnqueueMessage(Message.BuildWarningMessage(
+                        $"Failed to predict generated files for {grammarFile}: {ex.Message}"));
+                }
+            }
+
+            MessageQueue.EnqueueMessage(Message.BuildInfoMessage(
+                $"Predicted {generatedCodeFiles.Count} code files from {grammarFiles.Count()} grammar files."));
+
+            return true;
+        }
+
+        public override bool GenerateFiles(IEnumerable<string> grammarFiles, out bool success)
+        {
+            var arguments = BuildGenerationArguments(grammarFiles);
+
+            bool executed = ExecuteProcess(
+                NodeExecutable,
+                arguments,
+                HandleStdoutDataReceived,
+                HandleStderrDataReceived,
+                out int exitCode);
+
+            success = executed && exitCode == 0;
+            return executed;
+        }
+
+        private List<string> BuildGenerationArguments(IEnumerable<string> grammarFiles)
+        {
+            var arguments = new List<string>();
+
+            // antlr-ng script
+            arguments.Add(NormalizePath(AntlrNgPath));
+
+            // Output directory
+            arguments.Add("-o");
+            arguments.Add(NormalizePath(OutputDirectory));
+
+            // Library paths
+            if (!string.IsNullOrEmpty(LibPath))
+            {
+                foreach (var path in SplitAndFilterList(LibPath))
+                {
+                    arguments.Add("-lib");
+                    arguments.Add(NormalizePath(path));
+                }
+            }
+
+            // ATN generation
+            if (GenerateATN)
+                arguments.Add("--atn");
+
+            // Encoding
+            if (!string.IsNullOrEmpty(Encoding))
+            {
+                arguments.Add("-e");
+                arguments.Add(Encoding);
+            }
+
+            // Listener/Visitor generation
+            // Note: antlr-ng uses boolean values instead of -no-listener/-no-visitor
+            if (GenerateListener)
+            {
+                arguments.Add("-l");
+            }
+            else
+            {
+                arguments.Add("-l");
+                arguments.Add("false");
+            }
+
+            if (GenerateVisitor)
+            {
+                arguments.Add("-v");
+            }
+            else
+            {
+                arguments.Add("-v");
+                arguments.Add("false");
+            }
+
+            // Package/namespace
+            if (!string.IsNullOrEmpty(Package) && !string.IsNullOrWhiteSpace(Package))
+            {
+                arguments.Add("-p");
+                arguments.Add(Package);
+            }
+
+            // Grammar options
+            // Always ensure language=CSharp is set for antlr-ng
+            var hasLanguageOption = false;
+            if (!string.IsNullOrEmpty(DOptions))
+            {
+                foreach (var option in SplitAndFilterList(DOptions))
+                {
+                    if (option.StartsWith("language=", StringComparison.OrdinalIgnoreCase))
+                        hasLanguageOption = true;
+                    arguments.Add("-D");
+                    arguments.Add(option);
+                }
+            }
+
+            // Add language=CSharp if not already specified
+            if (!hasLanguageOption)
+            {
+                arguments.Add("-D");
+                arguments.Add("language=CSharp");
+            }
+
+            // Add separator to prevent grammar files from being interpreted as option values
+            arguments.Add("--");
+
+            // Grammar files
+            arguments.AddRange(grammarFiles.Select(NormalizePath));
+
+            return arguments;
+        }
+
+        private List<string> PredictGeneratedFiles(string grammarFile)
+        {
+            var result = new List<string>();
+            var grammarName = Path.GetFileNameWithoutExtension(grammarFile);
+            var outputDir = NormalizePath(OutputDirectory);
+
+            // Read grammar file to determine if it's a lexer, parser, or combined grammar
+            var grammarContent = File.ReadAllText(grammarFile);
+
+            bool isLexer = Regex.IsMatch(grammarContent, @"^\s*lexer\s+grammar\s+", RegexOptions.Multiline);
+            bool isParser = Regex.IsMatch(grammarContent, @"^\s*parser\s+grammar\s+", RegexOptions.Multiline);
+            bool isCombined = !isLexer && !isParser; // Combined grammar if no explicit type
+
+            // Predict generated files based on grammar type
+            if (isLexer || isCombined)
+            {
+                // Lexer files
+                result.Add(Path.Combine(outputDir, $"{grammarName}Lexer.cs"));
+                result.Add(Path.Combine(outputDir, $"{grammarName}.tokens"));
+
+                if (GenerateListener)
+                {
+                    // Lexers don't generate listeners in standard ANTLR
+                }
+            }
+
+            if (isParser || isCombined)
+            {
+                // Parser files
+                result.Add(Path.Combine(outputDir, $"{grammarName}Parser.cs"));
+
+                if (GenerateListener)
+                {
+                    result.Add(Path.Combine(outputDir, $"{grammarName}Listener.cs"));
+                    result.Add(Path.Combine(outputDir, $"{grammarName}BaseListener.cs"));
+                }
+
+                if (GenerateVisitor)
+                {
+                    result.Add(Path.Combine(outputDir, $"{grammarName}Visitor.cs"));
+                    result.Add(Path.Combine(outputDir, $"{grammarName}BaseVisitor.cs"));
+                }
+            }
+
+            // Combined grammars also generate .interp files
+            if (isCombined)
+            {
+                result.Add(Path.Combine(outputDir, $"{grammarName}Lexer.interp"));
+                result.Add(Path.Combine(outputDir, $"{grammarName}Parser.interp"));
+            }
+            else if (isLexer)
+            {
+                result.Add(Path.Combine(outputDir, $"{grammarName}Lexer.interp"));
+            }
+            else if (isParser)
+            {
+                result.Add(Path.Combine(outputDir, $"{grammarName}Parser.interp"));
+            }
+
+            // ATN files
+            if (GenerateATN)
+            {
+                if (isLexer || isCombined)
+                    result.Add(Path.Combine(outputDir, $"{grammarName}Lexer.dot"));
+                if (isParser || isCombined)
+                    result.Add(Path.Combine(outputDir, $"{grammarName}Parser.dot"));
+            }
+
+            return result;
+        }
+
+        private void HandleStdoutDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data == null)
+                return;
+
+            MessageQueue.EnqueueMessage(Message.BuildInfoMessage(e.Data));
+        }
+
+        private void HandleStderrDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data == null)
+                return;
+
+            var line = e.Data;
+
+            // antlr-ng error/warning format may differ from Java ANTLR
+            // Adjust parsing as needed based on actual output
+            if (line.ToLower().Contains("error"))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(line));
+            }
+            else if (line.ToLower().Contains("warning"))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildWarningMessage(line));
+            }
+            else
+            {
+                MessageQueue.EnqueueMessage(Message.BuildInfoMessage(line));
+            }
+        }
+    }
+}

--- a/Antlr4BuildTasks/Tools/AntlrToolBase.cs
+++ b/Antlr4BuildTasks/Tools/AntlrToolBase.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Antlr4.Build.Tasks;
+using Antlr4.Build.Tasks.Util;
+
+namespace Antlr4.Build.Tasks.Tools
+{
+    /// <summary>
+    /// Base class providing common functionality for ANTLR tool implementations
+    /// </summary>
+    public abstract class AntlrToolBase : IAntlrTool
+    {
+        protected AntlrToolBase()
+        {
+        }
+
+        public abstract string ToolName { get; }
+
+        public string OutputDirectory { get; set; }
+        public string LibPath { get; set; }
+        public bool GenerateATN { get; set; }
+        public bool EnableLogging { get; set; }
+        public bool LongMessages { get; set; }
+        public string Encoding { get; set; } = "UTF-8";
+        public bool GenerateListener { get; set; } = true;
+        public bool GenerateVisitor { get; set; } = true;
+        public string Package { get; set; }
+        public string DOptions { get; set; }
+        public bool TreatWarningsAsErrors { get; set; }
+        public bool ForceATN { get; set; }
+
+        public abstract bool Setup();
+
+        public abstract bool DiscoverGeneratedFiles(
+            IEnumerable<string> grammarFiles,
+            out List<string> generatedFiles,
+            out List<string> generatedCodeFiles);
+
+        public abstract bool GenerateFiles(IEnumerable<string> grammarFiles, out bool success);
+
+        /// <summary>
+        /// Joins command-line arguments, quoting those with spaces or special characters
+        /// </summary>
+        protected string JoinArguments(List<string> arguments)
+        {
+            var sb = new StringBuilder();
+            foreach (var arg in arguments)
+            {
+                if (sb.Length > 0)
+                    sb.Append(' ');
+
+                // Check if argument needs quoting
+                if (arg.Contains(' ') || arg.Contains('"'))
+                {
+                    sb.Append('"');
+                    // Escape any quotes in the argument
+                    sb.Append(arg.Replace("\"", "\\\""));
+                    sb.Append('"');
+                }
+                else
+                {
+                    sb.Append(arg);
+                }
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Executes a process and waits for it to complete
+        /// </summary>
+        protected bool ExecuteProcess(
+            string executable,
+            List<string> arguments,
+            DataReceivedEventHandler outputHandler,
+            DataReceivedEventHandler errorHandler,
+            out int exitCode)
+        {
+            try
+            {
+                var startInfo = new ProcessStartInfo(executable, JoinArguments(arguments))
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                };
+
+                MessageQueue.EnqueueMessage(Message.BuildInfoMessage(
+                    $"Executing command: \"{startInfo.FileName}\" {startInfo.Arguments}"));
+
+                using (var process = new Process())
+                {
+                    process.StartInfo = startInfo;
+
+                    if (errorHandler != null)
+                        process.ErrorDataReceived += errorHandler;
+
+                    if (outputHandler != null)
+                        process.OutputDataReceived += outputHandler;
+
+                    process.Start();
+                    process.BeginErrorReadLine();
+                    process.BeginOutputReadLine();
+                    process.StandardInput.Dispose();
+                    process.WaitForExit();
+
+                    exitCode = process.ExitCode;
+
+                    MessageQueue.EnqueueMessage(Message.BuildInfoMessage(
+                        $"Finished executing {ToolName} command with exit code {exitCode}."));
+
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(
+                    $"Failed to execute {ToolName}: {ex.Message}"));
+                exitCode = -1;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Normalizes path separators for the tool (forward slashes)
+        /// </summary>
+        protected string NormalizePath(string path)
+        {
+            return path?.Replace("\\", "/");
+        }
+
+        /// <summary>
+        /// Splits a semicolon-separated list and filters empty entries
+        /// </summary>
+        protected IEnumerable<string> SplitAndFilterList(string list)
+        {
+            if (string.IsNullOrEmpty(list))
+                return Enumerable.Empty<string>();
+
+            return list.Split(';')
+                .Select(s => s.Trim())
+                .Where(s => !string.IsNullOrWhiteSpace(s));
+        }
+    }
+}

--- a/Antlr4BuildTasks/Tools/IAntlrTool.cs
+++ b/Antlr4BuildTasks/Tools/IAntlrTool.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+
+namespace Antlr4.Build.Tasks.Tools
+{
+    /// <summary>
+    /// Interface for ANTLR tool implementations (Java-based ANTLR4, antlr-ng, etc.)
+    /// </summary>
+    public interface IAntlrTool
+    {
+        /// <summary>
+        /// Gets the name of the tool (e.g., "java", "antlr-ng")
+        /// </summary>
+        string ToolName { get; }
+
+        /// <summary>
+        /// Discovers the list of files that will be generated without actually generating them.
+        /// This is used for incremental build support.
+        /// </summary>
+        /// <param name="grammarFiles">List of grammar files to process</param>
+        /// <param name="generatedFiles">Output list of files that will be generated</param>
+        /// <param name="generatedCodeFiles">Output list of code files (.cs) that will be generated</param>
+        /// <returns>True if successful, false otherwise</returns>
+        bool DiscoverGeneratedFiles(
+            IEnumerable<string> grammarFiles,
+            out List<string> generatedFiles,
+            out List<string> generatedCodeFiles);
+
+        /// <summary>
+        /// Generates parser/lexer files from grammar files
+        /// </summary>
+        /// <param name="grammarFiles">List of grammar files to process</param>
+        /// <param name="success">Output parameter indicating if generation was successful</param>
+        /// <returns>True if the process executed, false if there was an error starting the process</returns>
+        bool GenerateFiles(IEnumerable<string> grammarFiles, out bool success);
+
+        /// <summary>
+        /// Sets up the tool environment (downloads required runtime, tool, etc.)
+        /// </summary>
+        /// <returns>True if setup was successful, false otherwise</returns>
+        bool Setup();
+
+        /// <summary>
+        /// Gets or sets the output directory for generated files
+        /// </summary>
+        string OutputDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the library search paths for imported grammars
+        /// </summary>
+        string LibPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to generate ATN diagrams
+        /// </summary>
+        bool GenerateATN { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to enable logging
+        /// </summary>
+        bool EnableLogging { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to use long error messages
+        /// </summary>
+        bool LongMessages { get; set; }
+
+        /// <summary>
+        /// Gets or sets the encoding for grammar files
+        /// </summary>
+        string Encoding { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to generate listener classes
+        /// </summary>
+        bool GenerateListener { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to generate visitor classes
+        /// </summary>
+        bool GenerateVisitor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package/namespace for generated code
+        /// </summary>
+        string Package { get; set; }
+
+        /// <summary>
+        /// Gets or sets grammar-level options (semicolon-separated key=value pairs)
+        /// </summary>
+        string DOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to treat warnings as errors
+        /// </summary>
+        bool TreatWarningsAsErrors { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to force ATN for all decisions
+        /// </summary>
+        bool ForceATN { get; set; }
+    }
+}

--- a/Antlr4BuildTasks/Tools/JavaAntlrTool.cs
+++ b/Antlr4BuildTasks/Tools/JavaAntlrTool.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Antlr4.Build.Tasks;
+using Antlr4.Build.Tasks.Util;
+
+namespace Antlr4.Build.Tasks.Tools
+{
+    /// <summary>
+    /// Implementation for the Java-based ANTLR4 tool
+    /// </summary>
+    public class JavaAntlrTool : AntlrToolBase
+    {
+        private readonly List<string> _generatedCodeFiles = new List<string>();
+        private readonly List<string> _generatedFiles = new List<string>();
+        private bool _start = false;
+        private readonly System.Text.StringBuilder _sb = new System.Text.StringBuilder();
+
+        public string JavaExecutable { get; set; }
+        public string AntlrJarPath { get; set; }
+
+        public JavaAntlrTool() : base()
+        {
+        }
+
+        public override string ToolName => "java";
+
+        public override bool Setup()
+        {
+            // Setup is expected to be done by the caller (SetupJava, SetupAntlrToolJar)
+            // This method just validates that the required components are available
+            if (string.IsNullOrEmpty(JavaExecutable))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(
+                    "Java executable path not set"));
+                return false;
+            }
+
+            if (!File.Exists(JavaExecutable))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(
+                    $"Java executable not found at: {JavaExecutable}"));
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(AntlrJarPath))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(
+                    "ANTLR JAR path not set"));
+                return false;
+            }
+
+            if (!File.Exists(AntlrJarPath))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(
+                    $"ANTLR JAR not found at: {AntlrJarPath}"));
+                return false;
+            }
+
+            return true;
+        }
+
+        public override bool DiscoverGeneratedFiles(
+            IEnumerable<string> grammarFiles,
+            out List<string> generatedFiles,
+            out List<string> generatedCodeFiles)
+        {
+            _generatedCodeFiles.Clear();
+            _generatedFiles.Clear();
+            _start = false;
+            _sb.Clear();
+
+            var arguments = BuildDependencyArguments(grammarFiles);
+
+            bool executed = ExecuteProcess(
+                JavaExecutable,
+                arguments,
+                HandleOutputDataReceivedFirstTime,
+                HandleStderrDataReceived,
+                out int exitCode);
+
+            if (!executed || exitCode != 0)
+            {
+                generatedFiles = new List<string>();
+                generatedCodeFiles = new List<string>();
+                return false;
+            }
+
+            MessageQueue.EnqueueMessage(Message.BuildInfoMessage(
+                $"The generated file list contains {_generatedCodeFiles.Count} items."));
+
+            // Add tokens files since ANTLR Tool doesn't list them in -depend output
+            var lexerFiles = _generatedCodeFiles.Where(s => s.EndsWith("Lexer.cs")).ToList();
+            foreach (var lexerFile in lexerFiles)
+            {
+                var directory = Path.GetDirectoryName(lexerFile);
+                var stem = Path.GetFileNameWithoutExtension(lexerFile);
+                var tokensFile = Path.Combine(directory, stem + ".tokens");
+                _generatedFiles.Add(tokensFile);
+            }
+
+            generatedFiles = _generatedFiles;
+            generatedCodeFiles = _generatedCodeFiles;
+            return true;
+        }
+
+        public override bool GenerateFiles(IEnumerable<string> grammarFiles, out bool success)
+        {
+            var arguments = BuildGenerationArguments(grammarFiles);
+
+            bool executed = ExecuteProcess(
+                JavaExecutable,
+                arguments,
+                HandleStdoutDataReceived,
+                HandleStderrDataReceived,
+                out int exitCode);
+
+            success = executed && exitCode == 0;
+            return executed;
+        }
+
+        private List<string> BuildDependencyArguments(IEnumerable<string> grammarFiles)
+        {
+            var arguments = new List<string>();
+
+            // Java classpath and main class
+            arguments.Add("-cp");
+            arguments.Add(NormalizePath(AntlrJarPath));
+            arguments.Add("org.antlr.v4.Tool");
+
+            // Dependency mode
+            arguments.Add("-depend");
+
+            // Common arguments
+            AddCommonArguments(arguments);
+
+            // Grammar files
+            arguments.AddRange(grammarFiles);
+
+            return arguments;
+        }
+
+        private List<string> BuildGenerationArguments(IEnumerable<string> grammarFiles)
+        {
+            var arguments = new List<string>();
+
+            // Java classpath and main class
+            arguments.Add("-cp");
+            arguments.Add(NormalizePath(AntlrJarPath));
+            arguments.Add("org.antlr.v4.Tool");
+
+            // Common arguments
+            AddCommonArguments(arguments);
+
+            // Logging (only for generation, not dependency discovery)
+            if (EnableLogging)
+                arguments.Add("-Xlog");
+
+            // Grammar files
+            arguments.AddRange(grammarFiles);
+
+            return arguments;
+        }
+
+        private void AddCommonArguments(List<string> arguments)
+        {
+            // Output directory
+            arguments.Add("-o");
+            arguments.Add(NormalizePath(OutputDirectory));
+
+            // Library paths
+            if (!string.IsNullOrEmpty(LibPath))
+            {
+                foreach (var path in SplitAndFilterList(LibPath))
+                {
+                    arguments.Add("-lib");
+                    arguments.Add(NormalizePath(path));
+                }
+            }
+
+            // ATN generation
+            if (GenerateATN)
+                arguments.Add("-atn");
+
+            // Long messages
+            if (LongMessages)
+                arguments.Add("-long-messages");
+
+            // Encoding
+            if (!string.IsNullOrEmpty(Encoding))
+            {
+                arguments.Add("-encoding");
+                arguments.Add(Encoding);
+            }
+
+            // Listener/Visitor generation
+            arguments.Add(GenerateListener ? "-listener" : "-no-listener");
+            arguments.Add(GenerateVisitor ? "-visitor" : "-no-visitor");
+
+            // Package/namespace
+            if (!string.IsNullOrEmpty(Package) && !string.IsNullOrWhiteSpace(Package))
+            {
+                arguments.Add("-package");
+                arguments.Add(Package);
+            }
+
+            // Grammar options
+            if (!string.IsNullOrEmpty(DOptions))
+            {
+                foreach (var option in SplitAndFilterList(DOptions))
+                {
+                    arguments.Add("-D" + option);
+                }
+            }
+
+            // Treat warnings as errors
+            if (TreatWarningsAsErrors)
+                arguments.Add("-Werror");
+
+            // Force ATN
+            if (ForceATN)
+                arguments.Add("-Xforce-atn");
+        }
+
+        private void HandleOutputDataReceivedFirstTime(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data == null)
+                return;
+
+            // Parse dependency output to extract generated files
+            // Format: <output-file> : <input-file1> <input-file2> ...
+            Regex regex = new Regex(@"^(?<OUTPUT>[^\n\r]+)\s{0,}[:]\s{1,}");
+            var match = regex.Match(e.Data);
+
+            if (match.Success && match.Groups["OUTPUT"].Length > 0)
+            {
+                var outputFile = match.Groups["OUTPUT"].Value.Trim();
+
+                if (!_start)
+                {
+                    _start = true;
+                    _sb.Clear();
+                }
+
+                _sb.Append(outputFile);
+                _generatedFiles.Add(outputFile);
+
+                if (outputFile.EndsWith(".cs"))
+                {
+                    _generatedCodeFiles.Add(outputFile);
+                }
+            }
+        }
+
+        private void HandleStdoutDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data == null)
+                return;
+
+            MessageQueue.EnqueueMessage(Message.BuildInfoMessage(e.Data));
+        }
+
+        private void HandleStderrDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data == null)
+                return;
+
+            // Parse ANTLR error/warning messages
+            // Format: error(code): message
+            // Format: warning(code): message
+            var line = e.Data;
+
+            if (line.Contains("error(") || line.ToLower().StartsWith("error"))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildErrorMessage(line));
+            }
+            else if (line.Contains("warning(") || line.ToLower().StartsWith("warning"))
+            {
+                MessageQueue.EnqueueMessage(Message.BuildWarningMessage(line));
+            }
+            else
+            {
+                MessageQueue.EnqueueMessage(Message.BuildInfoMessage(line));
+            }
+        }
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -126,6 +126,39 @@ to search PATH for an executable, or DOWNLOAD to download and use the `<JavaDown
 * `<AntlrToolJarDownloadDir>` -- Full path of the directory for download and use Antlr4 tool jar. If not set the default value is `$USERPROFILE/.m2/` and `$HOME/.m2/` to Windows and Linux respectively.
 * `<Log>` -- Adds'-Xlog' to Antlr4 Tool call, which turns on logging.
 * `<LongMessages>` -- Add '-long-messages' to Antlr4 Tool call, which turns on long messages.
+* `<ToolType>` -- Specifies which ANTLR tool to use: `java` (default) for the standard Java-based ANTLR4 tool, or `antlr-ng` for the Node.js-based antlr-ng tool.
+* `<NodeExec>` -- Path to Node.js executable (only used when `ToolType` is `antlr-ng`). Default is `PATH` to search system PATH.
+* `<AntlrNgPath>` -- Full path to antlr-ng CLI script (only used when `ToolType` is `antlr-ng`). If blank, searches common npm installation locations.
+
+### Using antlr-ng (Node.js-based ANTLR tool)
+
+As an alternative to the Java-based ANTLR tool, you can use [antlr-ng](https://github.com/antlr-ng/antlr-ng),
+a Node.js-based reimplementation of ANTLR that doesn't require Java.
+
+**Prerequisites:**
+- Node.js 20.x or later must be installed
+- antlr-ng must be installed globally (`npm install -g antlr-ng`) or locally in your project (`npm install --save-dev antlr-ng`)
+
+**To use antlr-ng, set the `ToolType` property:**
+
+````xml
+<ItemGroup>
+    <Antlr4 Include="MyGrammar.g4">
+        <ToolType>antlr-ng</ToolType>
+        <Visitor>true</Visitor>
+        <Package>MyNamespace</Package>
+    </Antlr4>
+</ItemGroup>
+````
+
+**Benefits of using antlr-ng:**
+- No Java runtime required
+- Faster startup time (no JVM initialization)
+- Native Node.js integration
+- Smaller footprint
+
+**Note:** antlr-ng automatically generates C# code when used with Antlr4BuildTasks. Most ANTLR options are supported,
+though some advanced Java-specific options (like `-Xlog`, `-Werror`) may not have antlr-ng equivalents.
 
 ### Customizing the Antlr4 tool JAR download location
 

--- a/_tests/single-antlr-ng/Arithmetic.g4
+++ b/_tests/single-antlr-ng/Arithmetic.g4
@@ -1,0 +1,32 @@
+// Template generated code from Antlr4Templates v5.0
+
+grammar Arithmetic;
+
+file : expression (SEMI expression)* EOF;
+expression : expression POW expression | expression (TIMES | DIV) expression | expression (PLUS | MINUS) expression | LPAREN expression RPAREN | (PLUS | MINUS)* atom ;
+atom : scientific | variable ;
+scientific : SCIENTIFIC_NUMBER ;
+variable : VARIABLE ;
+
+VARIABLE : VALID_ID_START VALID_ID_CHAR* ;
+SCIENTIFIC_NUMBER : NUMBER (E SIGN? UNSIGNED_INTEGER)? ;
+LPAREN : '(' ;
+RPAREN : ')' ;
+PLUS : '+' ;
+MINUS : '-' ;
+TIMES : '*' ;
+DIV : '/' ;
+GT : '>' ;
+LT : '<' ;
+EQ : '=' ;
+POINT : '.' ;
+POW : '^' ;
+SEMI : ';' ;
+WS : [ \r\n\t] + -> channel(HIDDEN) ;
+
+fragment VALID_ID_START : ('a' .. 'z') | ('A' .. 'Z') | '_' ;
+fragment VALID_ID_CHAR : VALID_ID_START | ('0' .. '9') ;
+fragment NUMBER : ('0' .. '9') + ('.' ('0' .. '9') +)? ;
+fragment UNSIGNED_INTEGER : ('0' .. '9')+ ;
+fragment E : 'E' | 'e' ;
+fragment SIGN : ('+' | '-') ;

--- a/_tests/single-antlr-ng/ErrorListener.cs
+++ b/_tests/single-antlr-ng/ErrorListener.cs
@@ -1,0 +1,22 @@
+﻿// Template generated code from Antlr4Templates v5.0
+namespace simple
+{
+	using Antlr4.Runtime;
+	using Antlr4.Runtime.Misc;
+	using System;
+	using System.Collections.Generic;
+	using System.IO;
+	using System.Linq;
+
+	public class ErrorListener<S> : ConsoleErrorListener<S>
+	{
+		public bool had_error;
+
+		public override void SyntaxError(TextWriter output, IRecognizer recognizer, S offendingSymbol, int line,
+			int col, string msg, RecognitionException e)
+		{
+			had_error = true;
+			base.SyntaxError(output, recognizer, offendingSymbol, line, col, msg, e);
+		}
+	}
+}

--- a/_tests/single-antlr-ng/Program.cs
+++ b/_tests/single-antlr-ng/Program.cs
@@ -1,0 +1,37 @@
+﻿// Template generated code from Antlr4Templates v5.0
+namespace simple
+{
+    using Antlr4.Runtime;
+    using System.Text;
+
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            Try("1 + 2 + 3");
+            Try("1 2 + 3");
+            Try("1 + +");
+        }
+
+        static void Try(string input)
+        {
+            var str = new AntlrInputStream(input);
+            System.Console.WriteLine(input);
+            var lexer = new ArithmeticLexer(str);
+            var tokens = new CommonTokenStream(lexer);
+            var parser = new ArithmeticParser(tokens);
+            var listener_lexer = new ErrorListener<int>();
+            var listener_parser = new ErrorListener<IToken>();
+            lexer.RemoveErrorListeners();
+            parser.RemoveErrorListeners();
+            lexer.AddErrorListener(listener_lexer);
+            parser.AddErrorListener(listener_parser);
+            var tree = parser.file();
+            if (listener_lexer.had_error || listener_parser.had_error)
+                System.Console.WriteLine("error in parse.");
+            else
+                System.Console.WriteLine("parse completed.");
+            System.Console.WriteLine(tree.ToStringTree(parser));
+        }
+    }
+}

--- a/_tests/single-antlr-ng/single-antlr-ng.csproj
+++ b/_tests/single-antlr-ng/single-antlr-ng.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>AntlrTemplate</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Antlr4 Include="Arithmetic.g4">
+      <Package>simple</Package>
+      <ToolType>antlr-ng</ToolType>
+      <NodeExec>PATH</NodeExec>
+    </Antlr4>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
+    <PackageReference Include="Antlr4BuildTasks" Version="12.11" />
+  </ItemGroup>
+
+</Project>

--- a/_tests/single-antlr-ng/test.sh
+++ b/_tests/single-antlr-ng/test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+where=`dirname -- "$0"`
+echo $where
+cd $where
+where=`pwd`
+
+# Check if Node.js is available
+echo "Checking for Node.js..."
+if ! command -v node &> /dev/null
+then
+    echo "Node.js not found. Please install Node.js to test antlr-ng."
+    exit 1
+fi
+node --version
+
+# Check if antlr-ng is available
+echo "Checking for antlr-ng..."
+if ! command -v antlr-ng &> /dev/null
+then
+    echo "antlr-ng not found globally. Checking local installation..."
+    if [ ! -f "node_modules/antlr-ng/cli.js" ]; then
+        echo "Installing antlr-ng locally..."
+        npm install --save-dev antlr-ng
+    fi
+fi
+
+# Determine OS and clean cached files
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)
+	echo Linux
+	machine=Linux
+	rm -rf ~/.jre
+	rm -rf ~/.nuget/packages/antlr4buildtasks
+	;;
+    Darwin*)
+	echo Mac
+	machine=Mac
+	rm -rf ~/.jre
+	rm -rf ~/.nuget/packages/antlr4buildtasks
+	;;
+    CYGWIN*)
+	echo Cygwin
+	machine=Cygwin
+	echo USERPROFILE = $USERPROFILE
+	rm -rf $USERPROFILE/.jre
+	rm -rf $USERPROFILE/.m2
+	rm -rf $USERPROFILE/.nuget/packages/antlr4buildtasks
+	;;
+    MINGW*)
+	echo Mingw
+	machine=MinGw
+	echo USERPROFILE = $USERPROFILE
+	rm -rf $USERPROFILE/.jre
+	rm -rf $USERPROFILE/.m2
+	rm -rf $USERPROFILE/.nuget/packages/antlr4buildtasks
+	;;
+    *)
+        machine="UNKNOWN:${unameOut}"
+esac
+
+cd "$where/../.."
+if [[ "$machine" == "MinGw" || "$machine" == "Msys" ]]
+then
+    cwd=`pwd -W | sed 's%/%\\\\%g'`
+    location="$cwd\\Antlr4BuildTasks\\bin\\Release\\"
+else
+    cwd=`pwd`
+    location="$cwd/Antlr4BuildTasks/bin/Release/"
+fi
+echo machine is "$machine"
+echo cwd is $cwd
+cd "$where"
+pwd
+
+# Setup local NuGet source
+dotnet nuget remove source nuget-a4bt > /dev/null 2>&1
+dotnet nuget list source | grep nuget-a4bt
+if [ "$?" = "0" ]
+then
+	echo Found antlr4buildtasks.
+	exit 1
+fi
+echo dotnet nuget add source $location --name nuget-a4bt
+dotnet nuget add source $location --name nuget-a4bt > /dev/null 2>&1
+
+# Build test project
+rm -rf bin obj
+dotnet restore single-antlr-ng.csproj -v normal
+result="$?"
+if [ "$result" != "0" ]
+then
+	exit $result
+fi
+
+dotnet build single-antlr-ng.csproj -v normal
+result="$?"
+if [ "$result" != "0" ]
+then
+	echo Test failed.
+	exit 1
+else
+	echo Test passed.
+	exit 0
+fi

--- a/test-antlr-ng.sh
+++ b/test-antlr-ng.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+bash _tests/single-antlr-ng/test.sh


### PR DESCRIPTION
This PR implements #92 by adding support for antlr-ng as an alternative ANTLR tool. The implementation uses a pluggable architecture with an IAntlrTool interface, allowing users to choose between the Java-based ANTLR4 tool (default) or the Node.js-based antlr-ng tool via the `<ToolType>` MSBuild property. Both tools share the same configuration options and work seamlessly within the existing build pipeline, with antlr-ng providing the benefit of not requiring a Java runtime. The implementation includes automatic Node.js and antlr-ng discovery, proper C# code generation with language target auto-detection, and a complete test suite validating the integration.