### PR TITLE
Add WorkingDirectory option for stable paths

### DIFF
--- a/Antlr4BuildTasks/Antlr4BuildTasks.targets
+++ b/Antlr4BuildTasks/Antlr4BuildTasks.targets
@@ -123,6 +123,7 @@
             <NodeDownloadDirectory>USERPROFILE/.node/</NodeDownloadDirectory>
             <AntlrNgPath></AntlrNgPath>
             <Visitor>true</Visitor>
+            <WorkingDirectory></WorkingDirectory>
         </Antlr4>
     </ItemDefinitionGroup>
 
@@ -169,6 +170,7 @@
                         NodeDownloadDirectory="%(Antlr4.NodeDownloadDirectory)"
                         AntlrNgPath="%(Antlr4.AntlrNgPath)"
                         Visitor="%(Antlr4.Visitor)"
+                        WorkingDirectory="%(Antlr4.WorkingDirectory)"
           >
             <Output ItemName="ToCompileFiles" TaskParameter="GeneratedCodeFiles" />
             <Output ItemName="AllFiles" TaskParameter="GeneratedFiles" />

--- a/Antlr4BuildTasks/Tasks/RunAntlrTool.cs
+++ b/Antlr4BuildTasks/Tasks/RunAntlrTool.cs
@@ -120,6 +120,7 @@ namespace Antlr4.Build.Tasks
         public string NodeExec { get; set; }
         public string NodeDownloadDirectory { get; set; }
         public string AntlrNgPath { get; set; }
+        public string WorkingDirectory { get; set; }
 
         public async System.Threading.Tasks.Task DownloadFileAsync(string uri, string outputPath)
         {
@@ -219,7 +220,8 @@ namespace Antlr4.Build.Tasks
                         Package = Package,
                         DOptions = DOptions,
                         TreatWarningsAsErrors = Error,
-                        ForceATN = ForceAtn
+                        ForceATN = ForceAtn,
+                        WorkingDirectory = WorkingDirectory
                     };
 
                     tool = ngTool;
@@ -253,7 +255,8 @@ namespace Antlr4.Build.Tasks
                         Package = Package,
                         DOptions = DOptions,
                         TreatWarningsAsErrors = Error,
-                        ForceATN = ForceAtn
+                        ForceATN = ForceAtn,
+                        WorkingDirectory = WorkingDirectory
                     };
 
                     tool = javaTool;

--- a/Antlr4BuildTasks/Tools/AntlrNgTool.cs
+++ b/Antlr4BuildTasks/Tools/AntlrNgTool.cs
@@ -189,8 +189,8 @@ namespace Antlr4.Build.Tasks.Tools
             // Add separator to prevent grammar files from being interpreted as option values
             arguments.Add("--");
 
-            // Grammar files
-            arguments.AddRange(grammarFiles.Select(NormalizePath));
+            // Grammar files - use relative path so "Generated from" comment is stable
+            arguments.AddRange(grammarFiles.Select(MakeGrammarRelativePath));
 
             return arguments;
         }

--- a/Antlr4BuildTasks/Tools/AntlrToolBase.cs
+++ b/Antlr4BuildTasks/Tools/AntlrToolBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -31,6 +32,7 @@ namespace Antlr4.Build.Tasks.Tools
         public string DOptions { get; set; }
         public bool TreatWarningsAsErrors { get; set; }
         public bool ForceATN { get; set; }
+        public string WorkingDirectory { get; set; }
 
         public abstract bool Setup();
 
@@ -89,6 +91,11 @@ namespace Antlr4.Build.Tasks.Tools
                     RedirectStandardError = true,
                 };
 
+                if (ShouldUseWorkingDirectory(WorkingDirectory))
+                {
+                    startInfo.WorkingDirectory = WorkingDirectory;
+                }
+
                 MessageQueue.EnqueueMessage(Message.BuildInfoMessage(
                     $"Executing command: \"{startInfo.FileName}\" {startInfo.Arguments}"));
 
@@ -134,6 +141,28 @@ namespace Antlr4.Build.Tasks.Tools
         }
 
         /// <summary>
+        /// Converts an absolute grammar file path to be relative to WorkingDirectory.
+        /// If WorkingDirectory is not set or does not exist, returns the path as-is (normalized).
+        /// </summary>
+        protected string MakeGrammarRelativePath(string grammarFile)
+        {
+            if (string.IsNullOrEmpty(grammarFile) || !ShouldUseWorkingDirectory(WorkingDirectory))
+                return NormalizePath(grammarFile);
+
+            var fullPath = Path.GetFullPath(grammarFile);
+            var workDir = Path.GetFullPath(WorkingDirectory);
+            if (!workDir.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                workDir += Path.DirectorySeparatorChar;
+
+            if (fullPath.StartsWith(workDir, StringComparison.OrdinalIgnoreCase))
+            {
+                return NormalizePath(fullPath.Substring(workDir.Length));
+            }
+
+            return NormalizePath(grammarFile);
+        }
+
+        /// <summary>
         /// Splits a semicolon-separated list and filters empty entries
         /// </summary>
         protected IEnumerable<string> SplitAndFilterList(string list)
@@ -144,6 +173,14 @@ namespace Antlr4.Build.Tasks.Tools
             return list.Split(';')
                 .Select(s => s.Trim())
                 .Where(s => !string.IsNullOrWhiteSpace(s));
+        }
+
+        /// <summary>
+        /// Returns true if WorkingDirectory is set and the directory exists on disk.
+        /// </summary>
+        private static bool ShouldUseWorkingDirectory(string workingDirectory)
+        {
+            return !string.IsNullOrEmpty(workingDirectory) && Directory.Exists(workingDirectory);
         }
     }
 }

--- a/Antlr4BuildTasks/Tools/IAntlrTool.cs
+++ b/Antlr4BuildTasks/Tools/IAntlrTool.cs
@@ -98,5 +98,12 @@ namespace Antlr4.Build.Tasks.Tools
         /// Gets or sets whether to force ATN for all decisions
         /// </summary>
         bool ForceATN { get; set; }
+
+        /// <summary>
+        /// Gets or sets the working directory for the tool process.
+        /// When set, grammar file paths are converted to be relative to this directory
+        /// so that the "Generated from" comment in output files uses relative paths.
+        /// </summary>
+        string WorkingDirectory { get; set; }
     }
 }

--- a/Antlr4BuildTasks/Tools/JavaAntlrTool.cs
+++ b/Antlr4BuildTasks/Tools/JavaAntlrTool.cs
@@ -145,8 +145,8 @@ namespace Antlr4.Build.Tasks.Tools
             // Common arguments
             AddCommonArguments(grammarFile.EndsWith("Parser.g4"), arguments);
 
-            // Grammar files
-            arguments.Add(grammarFile);
+            // Grammar files - use relative path so "Generated from" comment is stable
+            arguments.Add(MakeGrammarRelativePath(grammarFile));
 
             return arguments;
         }
@@ -167,8 +167,8 @@ namespace Antlr4.Build.Tasks.Tools
             if (EnableLogging)
                 arguments.Add("-Xlog");
 
-            // Grammar files
-            arguments.Add(grammarFile);
+            // Grammar files - use relative path so "Generated from" comment is stable
+            arguments.Add(MakeGrammarRelativePath(grammarFile));
 
             return arguments;
         }


### PR DESCRIPTION
Setting `WorkingDirectory` on the `<Antlr4>` item causes grammar file paths to be passed as relative to the tool process, producing stable "Generated from" comments that don't change per machine.

```diff
-// Generated from /Users/adeel/projects/runtime5/src/tools/ilasm/src/ILAssembler/gen/CIL.g4 by ANTLR 4.13.1
+// Generated from CIL.g4 by ANTLR 4.13.1
```

This avoids noisy diffs when regenerating on different machines or checkout paths.

Ref https://github.com/dotnet/runtime/pull/124764#discussion_r2845796918
